### PR TITLE
Fix patternSwitch.toggleRules type

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,10 @@
         "patternSwitch.toggleRules": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "default": [
             ["true", "false"],


### PR DESCRIPTION
## WHY & WHAT

Type of `patternSwitch.toggleRules` configuration is incorrect. So the `settings.json` has some warnings if I attempt to change the configuration. I fixed the type of items.

| before | after |
|---|---|
| ![image](https://user-images.githubusercontent.com/7839872/65959778-dd8c6c80-e48d-11e9-87b0-8d53a0863809.png) | ![image](https://user-images.githubusercontent.com/7839872/65959896-1d535400-e48e-11e9-80f7-48676d9c3987.png) |

